### PR TITLE
Fix run.py config loading path

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,7 +1,12 @@
 import yaml
+import os
 from src.core import run_simulation
 
 if __name__ == "__main__":
-    with open("config/default.yaml", "r") as f:
+    # Load the default configuration relative to this file so that running the
+    # script from another directory still works.
+    base_dir = os.path.dirname(os.path.abspath(__file__))
+    config_path = os.path.join(base_dir, "config", "default.yaml")
+    with open(config_path, "r") as f:
         config = yaml.safe_load(f)
     run_simulation(config)


### PR DESCRIPTION
## Summary
- ensure `run.py` finds the YAML config relative to the script location

## Testing
- `python -m py_compile run.py src/core.py src/models/percolation.py`
- `python run.py`
- `python Simulations/run.py` from parent directory

------
https://chatgpt.com/codex/tasks/task_e_684de573faf8833089108b63c7816ca7